### PR TITLE
fix missing display_intf_header

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1,3 +1,6 @@
+soong_namespace {
+}
+
 cc_library_headers {
     name: "display_intf_headers",
     vendor_available: true,


### PR DESCRIPTION
This is a commit to fix missing display_intf_header for msm8996 hal or any old devices.